### PR TITLE
Add configuration class

### DIFF
--- a/KountRisTest/ConfigurationTest.cs
+++ b/KountRisTest/ConfigurationTest.cs
@@ -1,0 +1,65 @@
+﻿using Kount.Ris;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace KountRisTest
+{
+    [TestClass]
+    public class ConfigurationTest
+    {
+        public Configuration SUT;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            SUT = Configuration.FromAppSettings();
+        }
+
+        [TestMethod]
+        public void FromAppSettings_assigns_Connect_Timeout()
+        {
+            Assert.AreEqual(SUT.ConnectTimeout, "10000");
+        }
+
+        [TestMethod]
+        public void FromAppSettings_assigns_MerchantId()
+        {
+            Assert.AreEqual(SUT.MerchantId, "000000");
+        }
+
+        [TestMethod]
+        public void FromAppSettings_assigns_API_Key()
+        {
+            Assert.AreEqual(SUT.ApiKey, "");
+        }
+
+        [TestMethod]
+        public void FromAppSettings_assigns_Version()
+        {
+            Assert.AreEqual(SUT.Version, "0695");
+        }
+
+        [TestMethod]
+        public void FromAppSettings_assigns_Url()
+        {
+            Assert.AreEqual(SUT.URL, "https://risk.beta.kount.net");
+        }
+
+        [TestMethod]
+        public void FromAppSettings_assigns_CertificateFile()
+        {
+            Assert.AreEqual(SUT.CertificateFile, "certificate.pfx");
+        }
+
+        [TestMethod]
+        public void FromAppSettings_assigns_PrivateKeyPassword()
+        {
+            Assert.AreEqual(SUT.PrivateKeyPassword, "11111111111111111");
+        }
+
+        [TestMethod]
+        public void FromAppSettings_assigns_ConfigKey()
+        {
+            Assert.AreEqual(SUT.ConfigKey, null);
+        }
+    }
+}

--- a/KountRisTest/KountRisTest.csproj
+++ b/KountRisTest/KountRisTest.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Base85EncodeDecodeTest.cs" />
     <Compile Include="MaskInquiryTest.cs" />
     <Compile Include="BasicConnectivityTest.cs" />
+    <Compile Include="ConfigurationTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PredictiveResponseTest.cs" />
     <Compile Include="TestHelper.cs" />

--- a/SDK/Kount/Ris/Configuration.cs
+++ b/SDK/Kount/Ris/Configuration.cs
@@ -1,0 +1,69 @@
+using System.Configuration;
+
+namespace Kount.Ris
+{
+    /// <summary>
+    /// Containing configuration values
+    /// </summary>
+    public class Configuration
+    {
+        /// <summary>
+        /// Gets configuration values from app settings.
+        /// </summary>
+        /// <returns>Configuration class with raw values.</returns>
+        public static Configuration FromAppSettings()
+        {
+            return new Configuration()
+            {
+                MerchantId = ConfigurationManager.AppSettings["Ris.MerchantId"],
+                URL = ConfigurationManager.AppSettings["Ris.Url"],
+                ConfigKey = ConfigurationManager.AppSettings["Ris.Config.Key"],
+                ConnectTimeout = ConfigurationManager.AppSettings["Ris.Connect.Timeout"],
+                Version = ConfigurationManager.AppSettings["Ris.Version"],
+                ApiKey = ConfigurationManager.AppSettings["Ris.API.Key"],
+                CertificateFile = ConfigurationManager.AppSettings["Ris.CertificateFile"],
+                PrivateKeyPassword = ConfigurationManager.AppSettings["Ris.PrivateKeyPassword"],
+            };
+        }
+
+        /// <summary>
+        /// Six digit identifier issued by Kount.
+        /// </summary>
+        public string MerchantId {get; set; }
+
+        /// <summary>
+        /// HTTPS URL path to the company's servers provided in boarding documentation from Kount.
+        /// </summary>
+        public string URL { get; set; }
+
+        /// <summary>
+        /// Config Key used in hashing method.
+        /// </summary>
+        public string ConfigKey { get; set; }
+
+        /// <summary>
+        /// RIS connect timeout value measured in milliseconds.
+        /// </summary>
+        public string ConnectTimeout { get; set; }
+
+        /// <summary>
+        /// RIS version
+        /// </summary>
+        public string Version { get; set; }
+
+        /// <summary>
+        /// API Key value from API Key page within Agent Web Console.
+        /// </summary>
+        public string ApiKey { get; set; }
+
+        /// <summary>
+        /// Full path of the certificate pk12 or pfx file.
+        /// </summary>
+        public string CertificateFile { get; set; }
+
+        /// <summary>
+        /// Password used to export the certificate
+        /// </summary>
+        public string PrivateKeyPassword { get; set; }
+    }
+}

--- a/SDK/Kount/Ris/Inquiry.cs
+++ b/SDK/Kount/Ris/Inquiry.cs
@@ -46,6 +46,24 @@ namespace Kount.Ris
         }
 
         /// <summary>
+        /// Constructor. Sets the mode to 'Q', the currency to 'USD' and sets
+        /// the SDK identifier value. Use SetMode(char) and SetCurrency(string)
+        /// to change the RIS mode and currency respectively.
+        /// </summary>
+        /// <param name="checkConfiguration">If is true: will check config file if 
+        /// `Ris.Url`, 
+        /// `Ris.MerchantId`, 
+        /// `Ris.Config.Key` and `Ris.Connect.Timeout` are set.</param>
+        /// <param name="configuration">Configuration class with raw values</param>
+        public Inquiry(bool checkConfiguration, Configuration configuration) : base(checkConfiguration, configuration)
+        {
+            this.SetMode(Enums.InquiryTypes.ModeQ);
+            this.SetCurrency("USD");
+            this.Data["SDK"] = ".NET";
+            this.SetSdkVersion("Sdk-Ris-Dotnet-0700");
+        }
+
+        /// <summary>
         /// Set the mode of the inquiry.
         /// </summary>
         /// <param name="mode">Set mode Q or P</param>

--- a/SDK/Kount/Ris/Request.cs
+++ b/SDK/Kount/Ris/Request.cs
@@ -86,43 +86,42 @@ namespace Kount.Ris
         {
             ILoggerFactory factory = LogFactory.GetLoggerFactory();
             this.logger = factory.GetLogger(typeof(Request).ToString());
+            Configuration configuration = Configuration.FromAppSettings();
 
             if (checkConfiguration)
             {
-                this.CheckConfigurationParameter("Ris.MerchantId");
-                this.CheckConfigurationParameter("Ris.Url");
-                this.CheckConfigurationParameter("Ris.Config.Key");
+                this.CheckConfigurationParameter(configuration.MerchantId, nameof(configuration.MerchantId));
+                this.CheckConfigurationParameter(configuration.URL, nameof(configuration.URL));
+                this.CheckConfigurationParameter(configuration.ConfigKey, nameof(configuration.ConfigKey));
             }
             
             // timeout must be always defined
-            this.CheckConfigurationParameter("Ris.Connect.Timeout");
+            this.CheckConfigurationParameter(configuration.ConnectTimeout, nameof(configuration.ConnectTimeout));
 
             this.data = new System.Collections.Hashtable();
-            this.SetMerchantId(Int32.Parse(
-                ConfigurationManager.AppSettings["Ris.MerchantId"]));
+            this.SetMerchantId(Int32.Parse(configuration.MerchantId));
 
-            Khash.ConfigKey = Khash.GetBase85ConfigKey(ConfigurationManager.AppSettings["Ris.Config.Key"]);
+            Khash.ConfigKey = Khash.GetBase85ConfigKey(configuration.ConfigKey);
 
-            var risVersion = String.IsNullOrEmpty(ConfigurationManager.AppSettings["Ris.Version"])
+            var risVersion = String.IsNullOrEmpty(configuration.Version)
                         ? RisVersion
-                        : ConfigurationManager.AppSettings["Ris.Version"];
+                        : configuration.Version;
 
             this.SetVersion(risVersion);
-            this.SetUrl(ConfigurationManager.AppSettings["Ris.Url"]);
-            this.connectTimeout = Int32.Parse(
-                ConfigurationManager.AppSettings["Ris.Connect.Timeout"]);
+            this.SetUrl(configuration.URL);
+            this.connectTimeout = Int32.Parse(configuration.ConnectTimeout);
 
-            if (!String.IsNullOrEmpty(ConfigurationManager.AppSettings["Ris.API.Key"]))
+            if (!String.IsNullOrEmpty(configuration.ApiKey))
             {
-                this.SetApiKey(ConfigurationManager.AppSettings["Ris.API.Key"]);
+                this.SetApiKey(configuration.ApiKey);
             }
             else
             {
-                this.CheckConfigurationParameter("Ris.CertificateFile");
-                this.CheckConfigurationParameter("Ris.PrivateKeyPassword");
+                this.CheckConfigurationParameter(configuration.CertificateFile, nameof(configuration.CertificateFile));
+                this.CheckConfigurationParameter(configuration.PrivateKeyPassword, nameof(configuration.PrivateKeyPassword));
                 this.SetCertificate(
-                    ConfigurationManager.AppSettings["Ris.CertificateFile"],
-                    ConfigurationManager.AppSettings["Ris.PrivateKeyPassword"]);
+                    configuration.CertificateFile,
+                    configuration.PrivateKeyPassword);
             }
 
             // KHASH payment encoding is set by default.
@@ -695,9 +694,9 @@ namespace Kount.Ris
         /// <param name="parameter">Parameter name</param>
         /// <exception cref="Kount.Ris.RequestException">Thrown when parameter
         /// is missing</exception>
-        protected void CheckConfigurationParameter(string parameter)
+        protected void CheckConfigurationParameter(string parameter, string value)
         {
-            if (null == ConfigurationManager.AppSettings[parameter])
+            if (null == value)
             {
                 this.logger.Error($"Configuration parameter [{parameter}] not defined.");
                 throw new Kount.Ris.RequestException(

--- a/SDK/Kount/Ris/Request.cs
+++ b/SDK/Kount/Ris/Request.cs
@@ -82,11 +82,10 @@ namespace Kount.Ris
         /// `Ris.Config.Key` are set.</param>
         /// <exception cref="Kount.Ris.RequestException">Thrown when there is
         /// static data missing for a RIS request.</exception>
-        protected Request(bool checkConfiguration = true)
+        protected Request(bool checkConfiguration, Configuration configuration)
         {
             ILoggerFactory factory = LogFactory.GetLoggerFactory();
             this.logger = factory.GetLogger(typeof(Request).ToString());
-            Configuration configuration = Configuration.FromAppSettings();
 
             if (checkConfiguration)
             {
@@ -126,6 +125,19 @@ namespace Kount.Ris
 
             // KHASH payment encoding is set by default.
             this.SetKhashPaymentEncoding(true);
+        }
+
+        /// <summary>
+        /// Construct a request object. Set the static setting from the web.config file.
+        /// </summary>
+        /// <param name="checkConfiguration">By default is true: will check config file if 
+        /// `Ris.Url`, 
+        /// `Ris.MerchantId`, 
+        /// `Ris.Config.Key` are set.</param>
+        /// <exception cref="Kount.Ris.RequestException">Thrown when there is
+        /// static data missing for a RIS request.</exception>
+        protected Request(bool checkConfiguration = true) : this(checkConfiguration, Configuration.FromAppSettings())
+        {
         }
 
         /// <summary>
@@ -694,7 +706,7 @@ namespace Kount.Ris
         /// <param name="parameter">Parameter name</param>
         /// <exception cref="Kount.Ris.RequestException">Thrown when parameter
         /// is missing</exception>
-        protected void CheckConfigurationParameter(string parameter, string value)
+        protected void CheckConfigurationParameter(string value, string parameter)
         {
             if (null == value)
             {

--- a/SDK/Kount/Ris/Update.cs
+++ b/SDK/Kount/Ris/Update.cs
@@ -60,6 +60,22 @@ namespace Kount.Ris
         }
 
         /// <summary>
+        /// Constructor. Sets the mode to 'U' by default.
+        /// Use setMode(char) to change it.
+        /// </summary>
+        /// <param name="checkConfiguration">If is true: will check config file if 
+        /// `Ris.Url`, 
+        /// `Ris.MerchantId`, 
+        /// `Ris.Config.Key` and `Ris.Connect.Timeout` are set.</param>
+        /// <param name="configuration">Configuration class with raw values</param>
+        public Update(bool checkConfiguration, Configuration configuration) : base(checkConfiguration, configuration)
+        {
+            ILoggerFactory factory = LogFactory.GetLoggerFactory();
+            this.logger = factory.GetLogger(typeof(Update).ToString());
+            this.SetMode(Enums.UpdateTypes.ModeU);
+        }
+
+        /// <summary>
         /// Set the mode of the update.
         /// </summary>
         /// <param name="mode">Set U or X</param>

--- a/SDK/KountRisSdk.csproj
+++ b/SDK/KountRisSdk.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Kount\Log\Factory\NopLoggerFactory.cs" />
     <Compile Include="Kount\Log\Factory\SimpleLoggerFactory.cs" />
     <Compile Include="Kount\Ris\CartItem.cs" />
+    <Compile Include="Kount\Ris\Configuration.cs" />
     <Compile Include="Kount\Ris\IllegalArgumentException.cs" />
     <Compile Include="Kount\Ris\Inquiry.cs" />
     <Compile Include="Kount\Ris\KcEvent.cs" />


### PR DESCRIPTION
This is to allow to create a configuration without the need of pulling it from the `app.config`.
The behaviour of `Inquiry` and `Update` are the same as before. I added additional constructors to them to allow to pass in a `Configuration` instance. 

