### PR TITLE
Updated Default SDK VERSION 0695 to 0700 for Dot Net

### DIFF
--- a/KountRisConfigTest/App.config
+++ b/KountRisConfigTest/App.config
@@ -7,7 +7,7 @@
     <add key="Ris.Config.Key" value="" />
     <add key="Ris.Url" value="" />
 
-    <add key="Ris.Version" value="0695" />
+    <add key="Ris.Version" value="0700" />
     <add key="Ris.CertificateFile" value="certificate.pfx" />
     <add key="Ris.PrivateKeyPassword" value="11111111111111111" />
     <add key="Ris.Connect.Timeout" value="10000" />

--- a/KountRisConfigTest/InquiryTest.cs
+++ b/KountRisConfigTest/InquiryTest.cs
@@ -418,7 +418,7 @@ namespace KountRisConfigTest
             // create Update
             Update update = new Update();
             update.SetMode(UpdateTypes.ModeU);
-            update.SetVersion("0695");
+            update.SetVersion("0700");
             update.SetSessionId(sessID);
             update.SetTransactionId(tranID);
             update.SetOrderNumber(ordNum);
@@ -485,7 +485,7 @@ namespace KountRisConfigTest
             // create update
             Update update = new Update();
             update.SetMode(UpdateTypes.ModeX);
-            update.SetVersion("0695");
+            update.SetVersion("0700");
 
             update.SetSessionId(sessID);
             update.SetTransactionId(tranID);

--- a/KountRisTest/App.config
+++ b/KountRisTest/App.config
@@ -9,7 +9,7 @@
     <add key="Ris.API.Key" value="" />
     <add key="Ris.Connect.Timeout" value="10000" />
 
-    <add key="Ris.Version" value="0695" />
+    <add key="Ris.Version" value="0700" />
     <add key="Ris.Url" value="https://risk.beta.kount.net" />
     <add key="Ris.CertificateFile" value="certificate.pfx" />
     <add key="Ris.PrivateKeyPassword" value="11111111111111111" />

--- a/KountRisTest/BasicConnectivityTest.cs
+++ b/KountRisTest/BasicConnectivityTest.cs
@@ -422,7 +422,7 @@ namespace KountRisTest
             // create Update
             Update update = new Update(false);
             update.SetMode(UpdateTypes.ModeU);
-            update.SetVersion("0695");
+            update.SetVersion("0700");
             update.SetMerchantId(TestHelper.TEST_MERCHANT_ID);
             update.SetApiKey(TestHelper.TEST_API_KEY);
             update.SetSessionId(sessID);
@@ -491,7 +491,7 @@ namespace KountRisTest
             // create update without check in config
             Update update = new Update(false);
             update.SetMode(UpdateTypes.ModeX);
-            update.SetVersion("0695");
+            update.SetVersion("0700");
 
             update.SetMerchantId(TestHelper.TEST_MERCHANT_ID);
             update.SetApiKey(TestHelper.TEST_API_KEY);

--- a/KountRisTest/ConfigurationTest.cs
+++ b/KountRisTest/ConfigurationTest.cs
@@ -35,7 +35,7 @@ namespace KountRisTest
         [TestMethod]
         public void FromAppSettings_assigns_Version()
         {
-            Assert.AreEqual(SUT.Version, "0695");
+            Assert.AreEqual(SUT.Version, "0700");
         }
 
         [TestMethod]

--- a/KountRisTest/MaskInquiryTest.cs
+++ b/KountRisTest/MaskInquiryTest.cs
@@ -417,7 +417,7 @@ namespace KountRisTest
 
             Update update = new Update(false);
             update.SetMode(UpdateTypes.ModeU);
-            update.SetVersion("0695");
+            update.SetVersion("0700");
             update.SetMerchantId(TestHelper.TEST_MERCHANT_ID);
             update.SetApiKey(TestHelper.TEST_API_KEY);
             update.SetSessionId(sessID);
@@ -479,7 +479,7 @@ namespace KountRisTest
             var ordNum = response.GetOrderNumber();
             Update update = new Update(false);
             update.SetMode(UpdateTypes.ModeX);
-            update.SetVersion("0695");
+            update.SetVersion("0700");
 
             update.SetMerchantId(TestHelper.TEST_MERCHANT_ID);
             update.SetApiKey(TestHelper.TEST_API_KEY);

--- a/SDK/App.config
+++ b/SDK/App.config
@@ -7,7 +7,7 @@
     <add key="Ris.Config.Key" value="Config key set here" />
     <add key="Ris.Url" value="https://risk.beta.kount.net" />
 
-    <add key="Ris.Version" value="0695" />
+    <add key="Ris.Version" value="0700" />
     <add key="Ris.CertificateFile" value="certificate.pfx" />
     <add key="Ris.PrivateKeyPassword" value="11111111111111111" />
     <add key="Ris.Connect.Timeout" value="10000" />

--- a/SDK/Kount/Ris/Request.cs
+++ b/SDK/Kount/Ris/Request.cs
@@ -35,7 +35,7 @@ namespace Kount.Ris
         /// <summary>
         /// The RIS version
         /// </summary>
-        private const string RisVersion = "0695";
+        private const string RisVersion = "0700";
 
         /// <summary>
         /// The Logger to use.

--- a/SDK/articles/testing.md
+++ b/SDK/articles/testing.md
@@ -509,7 +509,7 @@ public void ModeUAfterModeQ()
     // create Update
     Update update = new Update();
     update.SetMode('U');
-    update.SetVersion("0695");
+    update.SetVersion("0700");
     update.SetSessionId(sessID);
     update.SetTransactionId(tranID);
     update.SetOrderNumber(ordNum);
@@ -579,7 +579,7 @@ public void ModeXAfterModeQ()
     // create update
     Update update = new Update();
     update.SetMode('X');
-    update.SetVersion("0695");
+    update.SetVersion("0700");
 
     update.SetSessionId(sessID);
     update.SetTransactionId(tranID);


### PR DESCRIPTION
Updated default SDK version '0695' to '0700' for Dot Net SDK (all code).