### PR TITLE
Do not hardcode SecurityProtocolType values

### DIFF
--- a/SDK/Kount/Ris/Request.cs
+++ b/SDK/Kount/Ris/Request.cs
@@ -203,9 +203,9 @@ namespace Kount.Ris
             // Set up the request object
             HttpWebRequest webReq = (HttpWebRequest)WebRequest.Create(this.url);
 
-            // Force using TLS 1.2 in case is not default - per request framework 4.5, 4, 3.5
-            //System.Net.ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072 | (SecurityProtocolType)768;
-            System.Net.ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
+            // Instead of forcing specific security protocols make sure
+            // that deprecated security protocols are not being used
+            AssertSecurityProtocol();
 
             webReq.Timeout = this.connectTimeout;
             webReq.Method = "POST";
@@ -301,6 +301,17 @@ namespace Kount.Ris
 
             this.logger.Debug("End GetResponse()");
             return new Kount.Ris.Response(risString);
+        }
+
+        private static void AssertSecurityProtocol()
+        {
+            var securityProtocol = System.Net.ServicePointManager.SecurityProtocol;
+
+            if ((securityProtocol & SecurityProtocolType.Ssl3) == SecurityProtocolType.Ssl3
+                || (securityProtocol & SecurityProtocolType.Tls) == SecurityProtocolType.Tls)
+            {
+                throw new InvalidOperationException("We do not support SSL 3.0 and TLS 1.0. They have been deprecated. Make sure ServicePointManager.SecurityProtocol doesn't include deprecated security protocols. On .NET Framework 4.7 and higher one should prefer SecurityProtocolTyp.SystemDefault to allow the operating system to choose the best protocol to use.");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Hardcoding SecurityProtocolType values is a bad practice even with a good intentions.

1) It is generally expected that libraries do not change global application state.

2) Hardcoding SecurityProtocolType values could make caller application less secure and lead to bugs.
Consider scenario when application developer sets ServicePointManager.SecurityProtocol to SecurityProtocolType.Tls13.
After call to Kount value would change to use TLS 1.1 and 1.2.

3) This is a violation of Microsoft recommendation
https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca5386