### PR TITLE
Update Request.cs

### DIFF
--- a/SDK/Kount/Ris/Request.cs
+++ b/SDK/Kount/Ris/Request.cs
@@ -1160,7 +1160,7 @@ namespace Kount.Ris
             _bearerRefreshLock.AcquireWriterLock(TimeSpan.FromSeconds(30));
             
             // short circuit if another thread as already refreshed the token
-            if (_bearerAuthResponseExpiration >= DateTimeOffset.Now)
+            if (_bearerAuthResponseExpiration > DateTimeOffset.Now)
             {
                 _bearerRefreshLock.ReleaseWriterLock();
                 return;


### PR DESCRIPTION
_bearerAuthResponseExpiration is initialized with DateTimeOffset.Now . .  checking equality DateTimeOffset.Now from the constructor for a short circuit is likely to be true  . .  we only want to cancel refresh if the expiration is in the future, not when it's equal to it's initial state.  This change avoids first request RAF-MissingAccessToken 501 issues.